### PR TITLE
Corrected spelling error

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -29,7 +29,7 @@ func LoadConfig() {
 		Config.AWSSecretKey = os.Getenv("AWSSecretKey")
 
 		if Config.AWSAccessKeyID == "" || Config.AWSSecretKey == "" {
-			log.Fatalln("Cannot Get access key and secert key")
+			log.Fatalln("Cannot Get access key and secret key")
 		}
 	}
 }


### PR DESCRIPTION
Corrected a really small spelling error in auth/auth.go
"secert" to "secret".