### PR TITLE
Vultr parse response : compute, dns, storage, bare metal

### DIFF
--- a/baremetal/vultrbaremetal/baremetal_test.go
+++ b/baremetal/vultrbaremetal/baremetal_test.go
@@ -117,6 +117,31 @@ func TestVultrBareMetal_ListBareMetal(t *testing.T) {
 	t.Logf("Vultr BareMetal is listed successfully.")
 }
 
+func TestParseCreateBareMetalResp(t *testing.T) {
+	var vultrBareMetal VultrBareMetal
+	create := map[string]interface{}{
+		"DCID":        40,
+		"METALPLANID": 100,
+		"OSID":        127,
+	}
+	resp, err := vultrBareMetal.CreateBareMetal(create)
+	if err != nil {
+		t.Errorf("CreateBareMetal Test Fail: %s", err)
+		return
+	}
+	response := resp.(map[string]interface{})
+	if response["status"] != 200 {
+		t.Errorf("status code: %d\n response body: %s\n", response["status"], response["body"])
+		return
+	}
+	createBareMetalResp, err := ParseCreateBareMetalResp(response["body"])
+	if err != nil {
+		t.Errorf("CreateBareMetal Test Fail: %s", err)
+		return
+	}
+	t.Log(createBareMetalResp.SUBID)
+}
+
 func TestParseListBareMetalResp(t *testing.T) {
 	var vultrBareMetal VultrBareMetal
 	resp, err := vultrBareMetal.ListBareMetal(nil)

--- a/baremetal/vultrbaremetal/baremetal_test.go
+++ b/baremetal/vultrbaremetal/baremetal_test.go
@@ -12,7 +12,7 @@ func init() {
 func TestVultrBareMetal_CreateBareMetal(t *testing.T) {
 	var vultrBareMetal VultrBareMetal
 	create := map[string]interface{}{
-		"DCID":        1,
+		"DCID":        40,
 		"METALPLANID": 100,
 		"OSID":        127,
 	}
@@ -115,4 +115,28 @@ func TestVultrBareMetal_ListBareMetal(t *testing.T) {
 	}
 	t.Logf("response body: %s\n", response["body"])
 	t.Logf("Vultr BareMetal is listed successfully.")
+}
+
+func TestParseListBareMetalResp(t *testing.T) {
+	var vultrBareMetal VultrBareMetal
+	resp, err := vultrBareMetal.ListBareMetal(nil)
+	if err != nil {
+		t.Errorf("ListBareMetal Test Fail: %s", err)
+		return
+	}
+	response := resp.(map[string]interface{})
+	if response["status"] != 200 {
+		t.Errorf("status code: %d\n response body: %s\n", response["status"], response["body"])
+		return
+	}
+	t.Logf("response body: %s\n", response["body"])
+	listBareMetalResp, err := ParseListBareMetalResp(response["body"])
+	if err != nil {
+		t.Errorf("CreateNode Test Fail: %s", err)
+		return
+	}
+	t.Logf("Vultr BareMetal is listed successfully.")
+	for _, bareMetal := range listBareMetalResp {
+		t.Logf("%+v", bareMetal)
+	}
 }

--- a/baremetal/vultrbaremetal/resp.go
+++ b/baremetal/vultrbaremetal/resp.go
@@ -1,0 +1,101 @@
+package vultrbaremetal
+
+import (
+	"encoding/json"
+)
+
+type V6Network struct {
+	V6Network     string `json:"v6_network"`
+	V6MainIP      string `json:"v6_main_ip"`
+	V6NetworkSize int    `json:"v6_network_size"`
+}
+
+type BareMetalInfo struct {
+	SUBID           string
+	OS              string      `json:"os"`
+	RAM             string      `json:"ram"`
+	Disk            string      `json:"disk"`
+	MainIP          string      `json:"main_ip"`
+	CPUCount        float64     `json:"cpu_count"`
+	Location        string      `json:"location"`
+	DCID            string
+	DefaultPassword string      `json:"default_password"`
+	DateCreated     string      `json:"date_created"`
+	Status          string      `json:"status"`
+	NetmaskV4       string      `json:"netmask_v4"`
+	GatewayV4       string      `json:"gateway_v4"`
+	METALPLANID     float64
+	V6Networks      []V6Network `json:"v6_networks"`
+	Label           string      `json:"label"`
+	Tag             string      `json:"tag"`
+	OSID            string
+	APPID           string
+}
+
+func ParseListBareMetalResp(body interface{}) (listBareMetalResp []BareMetalInfo, err error) {
+	respMap := make(map[string]interface{})
+	err = json.Unmarshal([]byte(body.(string)), &respMap)
+	for _, bareMetal := range respMap {
+		bareMetalInfo := &BareMetalInfo{}
+		for key, value := range bareMetal.(map[string]interface{}) {
+			switch key {
+			case "SUBID":
+				bareMetalInfo.SUBID = value.(string)
+				break
+			case "os":
+				bareMetalInfo.OS = value.(string)
+				break
+			case "ram":
+				bareMetalInfo.RAM = value.(string)
+				break
+			case "disk":
+				bareMetalInfo.Disk = value.(string)
+				break
+			case "main_ip":
+				bareMetalInfo.MainIP = value.(string)
+				break
+			case "cpu_count":
+				bareMetalInfo.CPUCount = value.(float64)
+				break
+			case "location":
+				bareMetalInfo.Location = value.(string)
+				break
+			case "DCID":
+				bareMetalInfo.DCID = value.(string)
+				break
+			case "default_password":
+				bareMetalInfo.DefaultPassword = value.(string)
+				break
+			case "date_created":
+				bareMetalInfo.DateCreated = value.(string)
+				break
+			case "status":
+				bareMetalInfo.Status = value.(string)
+				break
+			case "netmask_v4":
+				bareMetalInfo.NetmaskV4 = value.(string)
+				break
+			case "gateway_v4":
+				bareMetalInfo.GatewayV4 = value.(string)
+				break
+			case "METALPLANID":
+				bareMetalInfo.METALPLANID = value.(float64)
+				break
+			case "label":
+				bareMetalInfo.Label = value.(string)
+				break
+			case "tag":
+				bareMetalInfo.Tag = value.(string)
+				break
+			case "OSID":
+				bareMetalInfo.OSID = value.(string)
+				break
+			case "APPID":
+				bareMetalInfo.APPID = value.(string)
+				break
+			}
+		}
+		listBareMetalResp = append(listBareMetalResp, *bareMetalInfo)
+	}
+	return
+}

--- a/baremetal/vultrbaremetal/resp.go
+++ b/baremetal/vultrbaremetal/resp.go
@@ -12,18 +12,18 @@ type V6Network struct {
 
 type BareMetalInfo struct {
 	SUBID           string
-	OS              string      `json:"os"`
-	RAM             string      `json:"ram"`
-	Disk            string      `json:"disk"`
-	MainIP          string      `json:"main_ip"`
-	CPUCount        float64     `json:"cpu_count"`
-	Location        string      `json:"location"`
+	OS              string  `json:"os"`
+	RAM             string  `json:"ram"`
+	Disk            string  `json:"disk"`
+	MainIP          string  `json:"main_ip"`
+	CPUCount        float64 `json:"cpu_count"`
+	Location        string  `json:"location"`
 	DCID            string
-	DefaultPassword string      `json:"default_password"`
-	DateCreated     string      `json:"date_created"`
-	Status          string      `json:"status"`
-	NetmaskV4       string      `json:"netmask_v4"`
-	GatewayV4       string      `json:"gateway_v4"`
+	DefaultPassword string `json:"default_password"`
+	DateCreated     string `json:"date_created"`
+	Status          string `json:"status"`
+	NetmaskV4       string `json:"netmask_v4"`
+	GatewayV4       string `json:"gateway_v4"`
 	METALPLANID     float64
 	V6Networks      []V6Network `json:"v6_networks"`
 	Label           string      `json:"label"`

--- a/baremetal/vultrbaremetal/resp.go
+++ b/baremetal/vultrbaremetal/resp.go
@@ -5,9 +5,9 @@ import (
 )
 
 type V6Network struct {
-	V6Network     string `json:"v6_network"`
-	V6MainIP      string `json:"v6_main_ip"`
-	V6NetworkSize int    `json:"v6_network_size"`
+	V6Network     string  `json:"v6_network"`
+	V6MainIP      string  `json:"v6_main_ip"`
+	V6NetworkSize float64 `json:"v6_network_size"`
 }
 
 type BareMetalInfo struct {
@@ -30,6 +30,15 @@ type BareMetalInfo struct {
 	Tag             string      `json:"tag"`
 	OSID            string
 	APPID           string
+}
+
+type CreateBareMetalResp struct {
+	SUBID string
+}
+
+func ParseCreateBareMetalResp(body interface{}) (createBareMetalResp CreateBareMetalResp, err error) {
+	err = json.Unmarshal([]byte(body.(string)), &createBareMetalResp)
+	return
 }
 
 func ParseListBareMetalResp(body interface{}) (listBareMetalResp []BareMetalInfo, err error) {
@@ -92,6 +101,29 @@ func ParseListBareMetalResp(body interface{}) (listBareMetalResp []BareMetalInfo
 				break
 			case "APPID":
 				bareMetalInfo.APPID = value.(string)
+				break
+			case "v6_networks":
+				_, ok := value.([]map[string]interface{})
+				if !ok {
+					break
+				}
+				for _, v6NetworksMap := range value.([]map[string]interface{}) {
+					v6Network := &V6Network{}
+					for key, value := range v6NetworksMap {
+						switch key {
+						case "v6_network":
+							v6Network.V6Network = value.(string)
+							break
+						case "v6_main_ip":
+							v6Network.V6MainIP = value.(string)
+							break
+						case "v6_network_size":
+							v6Network.V6NetworkSize = value.(float64)
+							break
+						}
+					}
+					bareMetalInfo.V6Networks = append(bareMetalInfo.V6Networks, *v6Network)
+				}
 				break
 			}
 		}

--- a/compute/vultrcompute/resp.go
+++ b/compute/vultrcompute/resp.go
@@ -1,0 +1,12 @@
+package vultrcompute
+
+import "encoding/json"
+
+type CreateNodeResp struct {
+	SUBID string
+}
+
+func ParseCreateNodeResp(body interface{}) (createNodeResp CreateNodeResp, err error) {
+	err = json.Unmarshal([]byte(body.(string)), &createNodeResp)
+	return
+}

--- a/compute/vultrcompute/server_test.go
+++ b/compute/vultrcompute/server_test.go
@@ -97,3 +97,28 @@ func TestVultrCompute_ListNode(t *testing.T) {
 	}
 	t.Logf("Vultr node list: %s", response["body"])
 }
+
+func TestParseCreateDiskResp(t *testing.T) {
+	var vultrServer VultrCompute
+	create := map[string]interface{}{
+		"DCID":      1,
+		"VPSPLANID": 201,
+		"OSID":      127,
+	}
+	resp, err := vultrServer.CreateNode(create)
+	if err != nil {
+		t.Errorf("CreateNode Test Fail: %s", err)
+		return
+	}
+	response := resp.(map[string]interface{})
+	if response["status"] != 200 {
+		t.Errorf("status code: %d\n response body: %s\n", response["status"], response["body"])
+		return
+	}
+	createNodeResp, err := ParseCreateNodeResp(response["body"])
+	if err != nil {
+		t.Errorf("CreateNode Test Fail: %s", err)
+		return
+	}
+	t.Logf("Vultr node is created successfully.\n %+v", createNodeResp)
+}

--- a/compute/vultrcompute/server_test.go
+++ b/compute/vultrcompute/server_test.go
@@ -98,7 +98,7 @@ func TestVultrCompute_ListNode(t *testing.T) {
 	t.Logf("Vultr node list: %s", response["body"])
 }
 
-func TestParseCreateDiskResp(t *testing.T) {
+func TestParseCreateNodeResp(t *testing.T) {
 	var vultrServer VultrCompute
 	create := map[string]interface{}{
 		"DCID":      1,

--- a/dns/vultrdns/dns_test.go
+++ b/dns/vultrdns/dns_test.go
@@ -157,6 +157,7 @@ func TestParseListDnsResp(t *testing.T) {
 		t.Errorf("status code: %d\n response body: %s\n", response["status"], response["body"])
 		return
 	}
+	t.Logf("response body: %s\n", response["body"])
 	listDnsResp, err := ParseListDnsResp(response["body"])
 	for _, dns := range listDnsResp {
 		t.Logf("%+v\n", dns)

--- a/dns/vultrdns/dns_test.go
+++ b/dns/vultrdns/dns_test.go
@@ -33,8 +33,8 @@ func TestVultrDNS_CreateDns(t *testing.T) {
 func TestCreateDNSBuilder(t *testing.T) {
 	var vultrDNS VultrDNS
 	createDNS, err := NewCreateDNSBuilder().
-		Domain("").
-		Name("gocloud.test").
+		Domain("oddcn.cn").
+		Name("gocloudtest1").
 		Type("A").
 		Data("192.0.2.1").
 		Build()
@@ -53,6 +53,7 @@ func TestCreateDNSBuilder(t *testing.T) {
 		return
 	}
 	t.Logf("Vultr DNS record is created successfully.")
+	t.Logf("status code: %d\n response body: %s\n", response["status"], response["body"])
 }
 
 func TestVultrDNS_ListDns(t *testing.T) {
@@ -135,4 +136,29 @@ func TestDeleteDNSBuilder(t *testing.T) {
 		return
 	}
 	t.Logf("Vultr DNS record is deleted")
+}
+
+func TestParseListDnsResp(t *testing.T) {
+	var vultrDNS VultrDNS
+	listDNS, err := NewListDNSBuilder().
+		Domain("oddcn.cn").
+		Build()
+	if err != nil {
+		t.Errorf("ListDns Test Fail: %s", err)
+		return
+	}
+	resp, err := vultrDNS.ListDns(listDNS)
+	if err != nil {
+		t.Errorf("ListDns Test Fail: %s", err)
+		return
+	}
+	response := resp.(map[string]interface{})
+	if response["status"] != 200 {
+		t.Errorf("status code: %d\n response body: %s\n", response["status"], response["body"])
+		return
+	}
+	listDnsResp, err := ParseListDnsResp(response["body"])
+	for _, dns := range listDnsResp {
+		t.Logf("%+v\n", dns)
+	}
 }

--- a/dns/vultrdns/resp.go
+++ b/dns/vultrdns/resp.go
@@ -1,0 +1,21 @@
+package vultrdns
+
+import (
+	"encoding/json"
+)
+
+type ListDnsResp []DnsInfo
+
+type DnsInfo struct {
+	Tpye     string `json:"tpye"`
+	Name     string `json:"name"`
+	Data     string `json:"data"`
+	Priority int    `json:"priority"`
+	RecordID int    `json:"RECORDID"`
+	Ttl      int    `json:"ttl"`
+}
+
+func ParseListDnsResp(body interface{}) (listDnsResp ListDnsResp, err error) {
+	err = json.Unmarshal([]byte(body.(string)), &listDnsResp)
+	return
+}

--- a/examples/baremetal/vultr_baremetal/vultr_baremetal.md
+++ b/examples/baremetal/vultr_baremetal/vultr_baremetal.md
@@ -84,6 +84,15 @@ vultr := gocloud.VultrProvider()
     response := resp.(map[string]interface{})
     fmt.Println(response["status"])
     fmt.Println(response["body"])
+    
+    
+    listBareMetalResp, err := vultrbaremetal.ParseListBareMetalResp(response["body"])
+    if err != nil {
+        fmt.Println(err)
+    }
+    for _, bareMetal := range listBareMetalResp {
+        fmt.Printf("%+v", bareMetal)
+    }
 ```
 
 ### Reboot

--- a/examples/baremetal/vultr_baremetal/vultr_baremetal.md
+++ b/examples/baremetal/vultr_baremetal/vultr_baremetal.md
@@ -39,6 +39,12 @@ vultr := gocloud.VultrProvider()
     response := resp.(map[string]interface{})
     fmt.Println(response["status"])
     fmt.Println(response["body"])
+    
+    createBareMetalResp, err := vultrbaremetal.ParseCreateBareMetalResp(response["body"])
+    if err != nil {
+        fmt.Println(err)
+    }
+    fmt.Println(createBareMetalResp.SUBID)
 ```
 
 ### Delete

--- a/examples/compute/vultr_compute/vultr_compute.md
+++ b/examples/compute/vultr_compute/vultr_compute.md
@@ -34,6 +34,12 @@ vultr, _ := gocloud.CloudProvider(gocloud.Vultrprovider)
     resp, err := vultrCloud.CreateNode(create)
     response := resp.(map[string]interface{})
     fmt.Println(response["body"])
+ 
+    createNodeResp, err := vultrcompute.ParseCreateNodeResp(response["body"])
+    if err != nil {
+        fmt.Println(err)
+    }
+    fmt.Println(createNodeResp.SUBID)
 ```
 
 ### Start instance

--- a/examples/dns/vultr_dns/vultr_dns.md
+++ b/examples/dns/vultr_dns/vultr_dns.md
@@ -112,6 +112,15 @@ or
     }
     response := resp.(map[string]interface{})
     fmt.Println(response["body"])
+
+    listDnsResp, err := vultrdns.ParseListDnsResp(response["body"])
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+    for _, dns := range listDnsResp {
+        fmt.Printf("%+v\n", dns)
+    }
 ```
 
 or
@@ -131,6 +140,15 @@ or
     }
     response := resp.(map[string]interface{})
     fmt.Println(response["body"])
+
+    listDnsResp, err := vultrdns.ParseListDnsResp(response["body"])
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+    for _, dns := range listDnsResp {
+        fmt.Printf("%+v\n", dns)
+    }
 ```
 
 ### List resource DNS record sets

--- a/examples/storage/vultr_storage/vultr_storage.md
+++ b/examples/storage/vultr_storage/vultr_storage.md
@@ -38,6 +38,13 @@ vultr, _ := gocloud.CloudProvider(gocloud.Vultrprovider)
     }
     response := resp.(map[string]interface{})
     fmt.Println(response["body"])
+    
+    createDiskResp, err := vultrstorage.ParseCreateDiskResp(response["body"])
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+    fmt.Printf(createDiskResp.SUBID)
 ```
 
 or
@@ -55,6 +62,13 @@ or
     }
     response := resp.(map[string]interface{})
     fmt.Println(response["body"])
+        
+    createDiskResp, err := vultrstorage.ParseCreateDiskResp(response["body"])
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+    fmt.Printf(createDiskResp.SUBID)
 ```
 
 ### Delete disk

--- a/gocloud/gocloudScalable.go
+++ b/gocloud/gocloudScalable.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cloudlibz/gocloud/gocloudinterface"
 	"github.com/cloudlibz/gocloud/google"
 	"github.com/cloudlibz/gocloud/vultr"
+	"github.com/cloudlibz/gocloud/vultrauth"
 )
 
 /**
@@ -131,6 +132,7 @@ type vultrProvider interface {
 
 // VultrProvider return Vultr API to users
 func VultrProvider() vultrProvider {
+	vultrauth.LoadConfig()
 	return new(vultr.Vultr)
 }
 

--- a/storage/vultrstorage/resp.go
+++ b/storage/vultrstorage/resp.go
@@ -1,0 +1,12 @@
+package vultrstorage
+
+import "encoding/json"
+
+type CreateDiskResp struct {
+	SUBID string `json:"SUBID"`
+}
+
+func ParseCreateDiskResp(body interface{}) (createDiskResp CreateDiskResp, err error) {
+	err = json.Unmarshal([]byte(body.(string)), &createDiskResp)
+	return
+}

--- a/storage/vultrstorage/storage_test.go
+++ b/storage/vultrstorage/storage_test.go
@@ -255,3 +255,32 @@ func TestNewDetachDiskBuilder(t *testing.T) {
 	}
 	t.Logf("Vultr disk is detached successfully.")
 }
+
+func TestParseCreateDiskResp(t *testing.T) {
+	var vultrStorage VultrStorage
+	createDisk, err := NewCreateDiskBuilder().
+		DCID(1).
+		SizeGb(50).
+		Label("test").
+		Build()
+	if err != nil {
+		t.Errorf("CreateDisk Test Fail: %s", err)
+		return
+	}
+	resp, err := vultrStorage.CreateDisk(createDisk)
+	if err != nil {
+		t.Errorf("CreateDisk Test Fail: %s", err)
+		return
+	}
+	response := resp.(map[string]interface{})
+	if response["status"] != 200 {
+		t.Errorf("status code: %d\n response body: %s\n", response["status"], response["body"])
+		return
+	}
+	createDiskResp, err := ParseCreateDiskResp(response["body"])
+	if err != nil {
+		t.Errorf("CreateDisk Test Fail: %s", err)
+		return
+	}
+	t.Logf("Vultr disk is created successfully.\n %+v", createDiskResp)
+}


### PR DESCRIPTION
user can use code below, to parse the result of listdDns()

the `func ParseListDnsResp(response["body"])` will return a slice of BareMetalInfo

BareMetalInfo is a struct

```
	listDnsResp, err := vultrdns.ParseListDnsResp(response["body"])
	if err != nil {
		fmt.Println(err)
		return
	}

	for _, dns := range listDnsResp {
		fmt.Printf("%+v\n", dns)
	}

	fmt.Println(listDnsResp[0].Data)
	fmt.Println(listDnsResp[0].Name)
	fmt.Println(listDnsResp[0].Priority)
	fmt.Println(listDnsResp[0].RecordID)
```

int this PR, implemented

- ParseListDnsResp()
- ParseCreateDiskResp()
- ParseCreateNodeResp()
- ParseCreateBareMetalResp()
- ParseListBareMetalResp()

and updated examples doc