### PR TITLE
Remove multiple useless linebreaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ GoCloud is a golang library which hides the difference between different APIs pr
 Currently, implementations for other cloud providers are being worked on.
 
 ## Installation instructions for Linux (Ubuntu)
-1. Install golang.  
+1. Install golang->  
    ```
    $ sudo apt-get update -y
    $ sudo apt-get install golang -y
@@ -95,7 +95,7 @@ $ go get golang.org/x/oauth2
 $ go get cloud.google.com/go/compute/metadata
 ```
 
-5. Create a directory called <b>.gocloud</b> in your <b>HOME</b> directory. Download your AWS, Google and DigitalOcean access credentials and store them in a file in your <b>.gocloud</b> folder.
+5. Create a directory called .gocloud in your <b>HOME</b> directory. Download your AWS, Google and DigitalOcean access credentials and store them in a file in your .gocloud folder.
 
    #### AWS:
    Save your AWS credentials in a file named *amazoncloudconfig.json*.

--- a/examples/analytics/bigquery/bigquery.md
+++ b/examples/analytics/bigquery/bigquery.md
@@ -1,9 +1,6 @@
 # gocloud analytics - bigquery
-
 ## Configure Google Cloud credentials.
-
 Download your service account credentials file from Google Cloud and save it as `googlecloudinfo.json` in your <b>HOME/.gocloud</b> directory.
-
 You can also set the credentials as environment variables:
 ```js
 export PrivateKey =  "xxxxxxxxxxxx"
@@ -17,120 +14,47 @@ export TokenURI = "xxxxxxxxxxxx"
 export AuthProviderX509CertURL = "xxxxxxxxxxxx"
 export ClientX509CertURL =  "xxxxxxxxxxxx"
 ```
-
 ## Initialize library
-
 ```js
-
 import "github.com/cloudlibz/gocloud/gocloud"
-
 googlecloud := gocloud.GoogleProvider()
-
 ```
-
 ### List Datasets
-
 ```js
-
-listDatasets := map[string]interface{}{
-	"ProjectId": "gocloud-206919",
-	"All" : true,
-	"Filter" : "",
-	"MaxResults" : 1,
-	"PageToken" : "",
-}
-
+listDatasets := map[string]interface{}{"ProjectId": "gocloud-206919","All" : true,"Filter" : "","MaxResults" : 1,"PageToken" : "",}
 resp, err := googlecloud.ListDatasets(listDatasets)
-
 response := resp.(map[string]interface{})
 fmt.Println(response["body"])
   ```
-
 ### Delete Datasets
-
 ```js
-
-deleteDatasets := map[string]string{
-	"ProjectId": "gocloud-206919",
-	"DatasetId" : "gocloudv2",
-}
-
+deleteDatasets := map[string]string{"ProjectId": "gocloud-206919","DatasetId" : "gocloudv2",}
 resp, err := googlecloud.DeleteDatasets(deleteDatasets)
-
 response := resp.(map[string]interface{})
-
 fmt.Println(response["body"])
 ```
-
 ### Get Datasets
-
 ```js
-
-getDatasets := map[string]string{
-	"ProjectId": "gocloud-206919",
-	"DatasetId" : "gocloudv3",
-}
-
+getDatasets := map[string]string{"ProjectId": "gocloud-206919","DatasetId" : "gocloudv3",}
 resp, err := googlecloud.GetDatasets(getDatasets)
-
 response := resp.(map[string]interface{})
 fmt.Println(response["body"])
-
 ```
-
 ### Create Datasets
-
 ```js
-datasetReference := map[string]string {
- "DatasetId": "gocloudv4",
- "ProjectId": "gocloud-206919",
-}
-
+datasetReference := map[string]string {"DatasetId": "gocloudv4","ProjectId": "gocloud-206919",}
 createDatasets := map[string]interface{}{
-	"ProjectId": "gocloud-206919",
-	"Description" : "gocloudv4 created",
-	"Kind": "bigquery#dataset",
-	"Etag": "wJ6J76UJduYf9EzfNz0gJw==",
-	"SelfLink": "https://www.googleapis.com/bigquery/v2/projects/gocloud-206919/datasets/gocloudv3",
-	 "Id": "gocloud-206919:gocloudv4",
-	"Location": "US",
-	"DatasetReference" : datasetReference,
-}
-
+	"ProjectId": "gocloud-206919","Description" : "gocloudv4 created","Kind": "bigquery#dataset","Etag": "wJ6J76UJduYf9EzfNz0gJw==","SelfLink": "https://www.googleapis.com/bigquery/v2/projects/gocloud-206919/datasets/gocloudv3","Id": "gocloud-206919:gocloudv4","Location": "US","DatasetReference" : datasetReference,}
 resp, err := googlecloud.CreateDatasets(createDatasets)
-
-
 response := resp.(map[string]interface{})
 fmt.Println(response["body"])
-
 ```
-
-
 ### Create update
-
 ```js
-datasetReference := map[string]string {
- "DatasetId": "gocloudv3",
- "ProjectId": "gocloud-206919",
-}
-
+datasetReference := map[string]string {"DatasetId": "gocloudv3","ProjectId": "gocloud-206919",}
 updateDatasets := map[string]interface{}{
-	"ProjectId": "gocloud-206919",
-	"Description" : "gocloudv3 created",
-	"Kind": "bigquery#dataset",
-	"Etag": "wJ6J76UJduYf9EzfNz0gJw==",
-	"SelfLink": "https://www.googleapis.com/bigquery/v2/projects/gocloud-206919/datasets/gocloudv3",
-	 "Id": "gocloud-206919:gocloudv3",
-	"Location": "US",
-	"DatasetReference" : datasetReference,
-	 "DatasetId": "gocloudv3",
-}
-
+	"ProjectId": "gocloud-206919","Description" : "gocloudv3 created","Kind": "bigquery#dataset","Etag": "wJ6J76UJduYf9EzfNz0gJw==","SelfLink": "https://www.googleapis.com/bigquery/v2/projects/gocloud-206919/datasets/gocloudv3","Id": "gocloud-206919:gocloudv3","Location": "US","DatasetReference" : datasetReference,"DatasetId": "gocloudv3",}
 resp, err := googlecloud.UpdateDatasets(updateDatasets)
-
-
 response := resp.(map[string]interface{})
 fmt.Println(response["body"])
-
-
 ```


### PR DESCRIPTION
Remove empty lines, shorten map data which was spread across multiple lines. Reduced 76 lines in /examples/analytics/bigquery/bigquery.md