### PR TITLE
Removing redundant comment

### DIFF
--- a/digioceanauth/digioceanauth.go
+++ b/digioceanauth/digioceanauth.go
@@ -11,7 +11,6 @@ type TokenSource struct {
 	DigiOceanAccessToken string
 }
 
-// Token is a variable of type TokenSource.
 var Token TokenSource
 
 // LoadConfig loads the DigitalOcean credentials.


### PR DESCRIPTION
It's clear by the declaration that it's a variable of type `TokenSource`.